### PR TITLE
Embedding list enum

### DIFF
--- a/business_objects/embedding.py
+++ b/business_objects/embedding.py
@@ -205,7 +205,10 @@ def get_tensors_and_attributes_for_qdrant(
                 payload_selector += f"'{attr}', r.\"data\"->>'{attr}'"
         payload_selector = f"json_build_object({payload_selector}) payload"
     query = f"""
-    SELECT et.record_id::TEXT, et."data", {payload_selector}
+    SELECT 
+        id::TEXT || CASE WHEN sub_key IS NULL THEN '' ELSE '@' || sub_key::TEXT END id, 
+        et."data", 
+        {payload_selector}
     FROM embedding_tensor et
     INNER JOIN record r
         ON et.project_id = r.project_id AND et.record_id = r.id

--- a/business_objects/embedding.py
+++ b/business_objects/embedding.py
@@ -265,7 +265,7 @@ def has_sub_key(
     query = f"""
     SELECT sub_key
     FROM embedding_tensor et
-    WHERE et.project_id = '{project_id}' et.embedding_id = '{embedding_id}'
+    WHERE et.project_id = '{project_id}' AND et.embedding_id = '{embedding_id}'
     LIMIT 1
     """
     value = general.execute_first(query)

--- a/business_objects/embedding.py
+++ b/business_objects/embedding.py
@@ -374,10 +374,10 @@ def create_tensors(
     tensors: List[List[float]],
     with_commit: bool = False,
 ) -> None:
-    tensors = None
+    to_add = None
     if len(record_ids) > 0 and "@" in record_ids[0]:
 
-        tensors = [
+        to_add = [
             EmbeddingTensor(
                 project_id=project_id,
                 record_id=record_id.split("@")[0],
@@ -388,7 +388,7 @@ def create_tensors(
             for record_id, tensor in zip(record_ids, tensors)
         ]
     else:
-        tensors = [
+        to_add = [
             EmbeddingTensor(
                 project_id=project_id,
                 record_id=record_id,
@@ -397,7 +397,7 @@ def create_tensors(
             )
             for record_id, tensor in zip(record_ids, tensors)
         ]
-    general.add_all(tensors, with_commit)
+    general.add_all(to_add, with_commit)
 
 
 def update_similarity_threshold(

--- a/business_objects/embedding.py
+++ b/business_objects/embedding.py
@@ -232,7 +232,7 @@ def get_match_record_ids_to_qdrant_ids(
     query = f"""
     SELECT et.record_id::TEXT
     FROM   embedding_tensor et
-    JOIN   UNNEST('{{{ids.join(",")}}}'::uuid[]) WITH ORDINALITY t(id, ord) USING (id)
+    JOIN   UNNEST('{{{",".join(ids)}}}'::uuid[]) WITH ORDINALITY t(id, ord) USING (id)
     GROUP BY et.record_id
     ORDER BY MIN(ord)
     LIMIT {limit}

--- a/business_objects/embedding.py
+++ b/business_objects/embedding.py
@@ -146,7 +146,8 @@ def get_tensors_by_project_id(project_id: str) -> List[Any]:
         SELECT
             et.embedding_id,
             et.record_id,
-            et.data
+            et.data,
+            et.sub_key
         FROM embedding_tensor et
         INNER JOIN embedding e
             ON et.embedding_id = e.id
@@ -316,12 +317,16 @@ def get_tensor_count(embedding_id: str) -> EmbeddingTensor:
     )
 
 
-def get_tensor(embedding_id: str, record_id: Optional[str] = None) -> EmbeddingTensor:
+def get_tensor(
+    embedding_id: str, record_id: Optional[str] = None, sub_key: Optional[int] = None
+) -> EmbeddingTensor:
     query = session.query(models.EmbeddingTensor).filter(
         models.EmbeddingTensor.embedding_id == embedding_id,
     )
     if record_id:
         query = query.filter(models.EmbeddingTensor.record_id == record_id)
+    if sub_key:
+        query = query.filter(models.EmbeddingTensor.sub_key == sub_key)
 
     return query.first()
 
@@ -393,6 +398,7 @@ def create_tensor(
     record_id: str,
     embedding_id: str,
     data: List[float],
+    sub_key: Optional[int] = None,
     with_commit: bool = False,
 ) -> EmbeddingTensor:
     embedding_tensor: EmbeddingTensor = EmbeddingTensor(
@@ -400,6 +406,7 @@ def create_tensor(
         record_id=record_id,
         embedding_id=embedding_id,
         data=data,
+        sub_key=sub_key,
     )
     general.add(embedding_tensor, with_commit)
     return embedding_tensor

--- a/business_objects/embedding.py
+++ b/business_objects/embedding.py
@@ -206,7 +206,7 @@ def get_tensors_and_attributes_for_qdrant(
         payload_selector = f"json_build_object({payload_selector}) payload"
     query = f"""
     SELECT 
-        id::TEXT || CASE WHEN sub_key IS NULL THEN '' ELSE '@' || sub_key::TEXT END id, 
+        et.id::TEXT || CASE WHEN sub_key IS NULL THEN '' ELSE '@' || sub_key::TEXT END id, 
         et."data", 
         {payload_selector}
     FROM embedding_tensor et

--- a/business_objects/embedding.py
+++ b/business_objects/embedding.py
@@ -236,6 +236,22 @@ def get_manually_labeled_tensors_by_embedding_id(
     return general.execute_all(query)
 
 
+def has_sub_key(
+    project_id: str,
+    embedding_id: str,
+) -> bool:
+    query = f"""
+    SELECT sub_key
+    FROM embedding_tensor et
+    WHERE et.project_id = '{project_id}' et.embedding_id = '{embedding_id}'
+    LIMIT 1
+    """
+    value = general.execute_first(query)
+    if value is None or value[0] is None:
+        return False
+    return True
+
+
 def get_not_manually_labeled_tensors_by_embedding_id(
     project_id: str,
     embedding_id: str,

--- a/business_objects/embedding.py
+++ b/business_objects/embedding.py
@@ -248,7 +248,7 @@ def get_qdrant_limit_factor(
     FROM (
         SELECT record_id, MAX(sub_key + 1) max_key
         FROM embedding_tensor et
-        WHERE project_id = '4eb4438f-e1ba-4a42-86d8-f8b7ec88fdb2' AND embedding_id = 'c0fe77af-87cd-435a-a1a2-34a5751358e5'
+        WHERE project_id = '{project_id}' AND embedding_id = '{embedding_id}'
         GROUP BY record_id )x """
     value = general.execute_first(query)
     if value is None or value[0] is None:

--- a/business_objects/embedding.py
+++ b/business_objects/embedding.py
@@ -240,6 +240,22 @@ def get_match_record_ids_to_qdrant_ids(
     return [r[0] for r in general.execute_all(query)]
 
 
+def get_qdrant_limit_factor(
+    project_id: str, embedding_id: str, default: int = 1
+) -> int:
+    query = f"""
+    SELECT CEIL(AVG(max_key))::INTEGER
+    FROM (
+        SELECT record_id, MAX(sub_key + 1) max_key
+        FROM embedding_tensor et
+        WHERE project_id = '4eb4438f-e1ba-4a42-86d8-f8b7ec88fdb2' AND embedding_id = 'c0fe77af-87cd-435a-a1a2-34a5751358e5'
+        GROUP BY record_id )x """
+    value = general.execute_first(query)
+    if value is None or value[0] is None:
+        return default
+    return value[0]
+
+
 def get_manually_labeled_tensors_by_embedding_id(
     project_id: str,
     embedding_id: str,

--- a/business_objects/embedding.py
+++ b/business_objects/embedding.py
@@ -355,15 +355,29 @@ def create_tensors(
     tensors: List[List[float]],
     with_commit: bool = False,
 ) -> None:
-    tensors = [
-        EmbeddingTensor(
-            project_id=project_id,
-            record_id=record_id,
-            embedding_id=embedding_id,
-            data=tensor,
-        )
-        for record_id, tensor in zip(record_ids, tensors)
-    ]
+    tensors = None
+    if len(record_ids) > 0 and "@" in record_ids[0]:
+
+        tensors = [
+            EmbeddingTensor(
+                project_id=project_id,
+                record_id=record_id.split("@")[0],
+                embedding_id=embedding_id,
+                data=tensor,
+                sub_key=int(record_id.split("@")[1]),
+            )
+            for record_id, tensor in zip(record_ids, tensors)
+        ]
+    else:
+        tensors = [
+            EmbeddingTensor(
+                project_id=project_id,
+                record_id=record_id,
+                embedding_id=embedding_id,
+                data=tensor,
+            )
+            for record_id, tensor in zip(record_ids, tensors)
+        ]
     general.add_all(tensors, with_commit)
 
 

--- a/business_objects/record.py
+++ b/business_objects/record.py
@@ -363,7 +363,7 @@ def get_attribute_data(
         )x """
     else:
         query = f"""
-        SELECT id, data::JSON->'{attribute_name}' AS "{attribute_name}"
+        SELECT id::TEXT, data::JSON->'{attribute_name}' AS "{attribute_name}"
         FROM record
         WHERE project_id = '{project_id}'
         {order}

--- a/business_objects/record.py
+++ b/business_objects/record.py
@@ -353,11 +353,11 @@ def get_attribute_data(
     order = __get_order_by(project_id)
     if attribute.get_by_name(project_id, attribute_name).data_type == "EMBEDDING_LIST":
         query = f"""
-        SELECT id::TEXT || '@' || sub_key id, att AS "attribute_5"
+        SELECT id::TEXT || '@' || sub_key id, att AS "{attribute_name}"
         FROM (
             SELECT id, value as att, ordinality - 1 as sub_key
             FROM record
-            cross join json_array_elements_text((data::JSON->'attribute_5')) with ordinality
+            cross join json_array_elements_text((data::JSON->'{attribute_name}')) with ordinality
             WHERE project_id = '{project_id}'
             {order} 
         )x """

--- a/business_objects/record.py
+++ b/business_objects/record.py
@@ -352,13 +352,22 @@ def get_attribute_data(
     query = None
     if attribute.get_by_name(project_id, attribute_name).data_type == "EMBEDDING_LIST":
         # partition already orders by id
+        # query = f"""
+        # SELECT id::TEXT || '@' || ROW_NUMBER() OVER(PARTITION BY id::TEXT) id, att AS "{attribute_name}"
+        # FROM (
+        #     SELECT id, json_array_elements((data::JSON->'{attribute_name}')) AS att
+        #     FROM record
+        #     WHERE project_id = '{project_id}' )x
+        # """
         query = f"""
-        SELECT id::TEXT || '@' || TO_CHAR(ROW_NUMBER() OVER(PARTITION BY id::TEXT), 'fm000') id, att AS "{attribute_name}"
+        SELECT id::TEXT || '@' || sub_key id, att AS "attribute_5"
         FROM (
-            SELECT id, json_array_elements((data::JSON->'{attribute_name}')) AS att
+            SELECT id, value as att, ordinality - 1 as sub_key
             FROM record
-            WHERE project_id = '{project_id}' )x
-        """
+            cross join json_array_elements_text((data::JSON->'attribute_5')) with ordinality
+            WHERE project_id = '{project_id}'
+            {order} 
+        )x """
     else:
         order = __get_order_by(project_id)
         query = f"""

--- a/business_objects/record.py
+++ b/business_objects/record.py
@@ -350,15 +350,8 @@ def get_attribute_data(
     project_id: str, attribute_name: str
 ) -> Tuple[List[str], List[str]]:
     query = None
+    order = __get_order_by(project_id)
     if attribute.get_by_name(project_id, attribute_name).data_type == "EMBEDDING_LIST":
-        # partition already orders by id
-        # query = f"""
-        # SELECT id::TEXT || '@' || ROW_NUMBER() OVER(PARTITION BY id::TEXT) id, att AS "{attribute_name}"
-        # FROM (
-        #     SELECT id, json_array_elements((data::JSON->'{attribute_name}')) AS att
-        #     FROM record
-        #     WHERE project_id = '{project_id}' )x
-        # """
         query = f"""
         SELECT id::TEXT || '@' || sub_key id, att AS "attribute_5"
         FROM (
@@ -369,7 +362,6 @@ def get_attribute_data(
             {order} 
         )x """
     else:
-        order = __get_order_by(project_id)
         query = f"""
         SELECT id, data::JSON->'{attribute_name}' AS "{attribute_name}"
         FROM record

--- a/business_objects/record.py
+++ b/business_objects/record.py
@@ -376,6 +376,17 @@ def get_attribute_data(
 def count(project_id: str) -> int:
     return session.query(Record).filter(Record.project_id == project_id).count()
 
+def count_attribute_list_entries(project_id: str,attribute_name:str) -> int:
+    query = f"""
+    SELECT sum(json_array_length(r.data->'{attribute_name}'))
+    FROM record  r
+    WHERE project_id = '{project_id}'
+    """
+    value = general.execute_first(query)
+    if not value or not value[0]:
+        return 0
+    return value[0] 
+
 
 def count_by_project_and_source(
     project_id: str, record_category: str, label_source: str

--- a/enums.py
+++ b/enums.py
@@ -7,6 +7,7 @@ class DataTypes(Enum):
     BOOLEAN = "BOOLEAN"
     CATEGORY = "CATEGORY"
     TEXT = "TEXT"
+    EMBEDDING_LIST = "EMBEDDING_LIST"  # only for embeddings & default hidden
     UNKNOWN = "UNKNOWN"
 
 

--- a/models.py
+++ b/models.py
@@ -763,6 +763,7 @@ class EmbeddingTensor(Base):
         ForeignKey(f"{Tablenames.EMBEDDING.value}.id", ondelete="CASCADE"),
         index=True,
     )
+    sub_key = Column(Integer)
     data = Column(JSON)
 
 


### PR DESCRIPTION
- https://github.com/code-kern-ai/refinery-gateway/pull/148
- https://github.com/code-kern-ai/refinery-submodule-model/pull/51
- https://github.com/code-kern-ai/refinery-ac-exec-env/pull/27
- https://github.com/code-kern-ai/refinery-embedder/pull/58
- https://github.com/code-kern-ai/refinery-ui/pull/153
- https://github.com/code-kern-ai/refinery-neural-search/pull/36
- https://github.com/code-kern-ai/gates-runtime/pull/31


Note:
Gates was pretty much left untouched for the moment since other prs that change the structure are still in review queue & I'm unsure how we want to approach gates in the future (specify what is wanted, e.g. the new embedding_list attribute is atm fully returned etc,)

Best option to test:
`sudo bash start -g -b embedding-list` (newest dev setup version is needed -> this will start refinery & gates on the specified branch)

**otherwise:** remember to build the ac exec env & gates runtime to test :) 


