### PR TITLE
Adds wrapper for a deamon with a db token

### DIFF
--- a/business_objects/general.py
+++ b/business_objects/general.py
@@ -67,7 +67,7 @@ def force_remove_and_refresh_session_by_id(session_id: str) -> bool:
         if session_id not in session_lookup:
             return False
     # context vars cant be closed from a different context but we can work around it by using a thread (which creates a new context) with the same id
-    daemon.run(__close_in_context(session_id))
+    daemon.run_without_db_token(__close_in_context(session_id))
     return True
 
 

--- a/daemon.py
+++ b/daemon.py
@@ -1,7 +1,13 @@
 import threading
+from submodules.model.business_objects import general
+from contextvars import ContextVar
+import traceback
+
+thread_session_token = ContextVar("token", default=None)
 
 
-def run(target, *args, **kwargs):
+def run_without_db_token(target, *args, **kwargs):
+    """DB session token isn't automatically created. You can still do this with general.get_ctx_token but need to return it yourself with remove_and_refresh_session."""
     threading.Thread(
         target=target,
         args=args,
@@ -10,10 +16,35 @@ def run(target, *args, **kwargs):
     ).start()
 
 
-def prepare_thread(target, *args, **kwargs) -> threading.Thread:
-    return threading.Thread(
-        target=target,
-        args=args,
-        kwargs=kwargs,
+def run_with_db_token(target, *args, **kwargs):
+    """DB session token is automatically created & returned at the end. Long running threads needs to occasionally daemon.reset_session_token_in_thread to ensure the session doesn't get a timeout."""
+
+    # this is a workaround to set the token in the actual thread context
+    def wrapper():
+        token = general.get_ctx_token()
+        thread_session_token.set(token)
+        try:
+            target(*args, **kwargs)
+        except Exception:
+            print("=== Exception in thread ===", flush=True)
+            print(traceback.format_exc(), flush=True)
+            print("===========================", flush=True)
+        finally:
+            reset_session_token_in_thread(False)
+
+    threading.Thread(
+        target=wrapper,
         daemon=True,
-    )
+    ).start()
+
+
+def reset_session_token_in_thread(request_new: bool = True):
+    token = thread_session_token.get()
+    if not token:
+        # shouldn't happen if used with the run_with_session_token function
+        # so we print where it was called from
+        print(traceback.format_stack())
+        raise ValueError("No token set in thread context")
+    new_token = general.remove_and_refresh_session(token, request_new)
+    if new_token:
+        thread_session_token.set(new_token)

--- a/daemon.py
+++ b/daemon.py
@@ -48,3 +48,12 @@ def reset_session_token_in_thread(request_new: bool = True):
     new_token = general.remove_and_refresh_session(token, request_new)
     if new_token:
         thread_session_token.set(new_token)
+
+
+def prepare_thread(target, *args, **kwargs) -> threading.Thread:
+    return threading.Thread(
+        target=target,
+        args=args,
+        kwargs=kwargs,
+        daemon=True,
+    )


### PR DESCRIPTION
- https://github.com/code-kern-ai/refinery-submodule-model/pull/131
- https://github.com/code-kern-ai/refinery-gateway/pull/258


### Notes
Other repos can be changed as well, since they dont use the submodule deamon version so far this is mostly a proof of concept.