### PR TITLE
Session cleanup thread

### DIFF
--- a/session.py
+++ b/session.py
@@ -5,6 +5,9 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.exc import PendingRollbackError
 import traceback
+from . import daemon
+from .business_objects import general
+import time
 from .util import collect_engine_variables
 
 request_id_ctx_var = ContextVar("request_id", default=None)
@@ -59,3 +62,22 @@ def get_engine_dialect() -> Any:
     if not engine:
         return None
     return engine.dialect
+
+
+def start_session_cleanup_thread():
+    """
+    Starts a thread that will try to forcefully remove all sessions that are older than 5 minutes.
+    """
+    daemon.run_without_db_token(__start_session_cleanup)
+
+
+def __start_session_cleanup():
+    while True:
+        sessions = general.get_session_lookup(exclude_last_x_seconds=5 * 60)
+        for session in sessions:
+            try:
+                general.force_remove_and_refresh_session_by_id(session["session_id"])
+                print("Session removed", session, flush=True)
+            except Exception:
+                traceback.print_exc()
+        time.sleep(10)


### PR DESCRIPTION
PRs:
- https://github.com/code-kern-ai/refinery-submodule-model/pull/134
- https://github.com/code-kern-ai/refinery-gateway/pull/261
- https://github.com/code-kern-ai/cognition-gateway/pull/165


Adds a function that can be called on startup by a container to clean up unused session tokens