### PR TITLE
opengrep: apply agent fixes

### DIFF
--- a/business_objects/task_queue.py
+++ b/business_objects/task_queue.py
@@ -6,7 +6,7 @@ from .. import enums
 from ..models import TaskQueue, Project
 from ..session import session
 
-from ..util import prevent_sql_injection
+from ..util import prevent_sql_injection, get_sql_text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql.expression import cast
 from datetime import datetime, timedelta
@@ -41,9 +41,13 @@ def get_all_queued_etl_task_for_conversation(
         .filter(
             TaskQueue.organization_id == org_id,
             TaskQueue.task_type == enums.TaskType.EXECUTE_ETL.value,
-            text(f"task_info->'tmp_doc_metadata'->>'project_id' = '{project_id}'"),
-            text(
-                f"task_info->'tmp_doc_metadata'->>'conversation_id' = '{conversation_id}'"
+            get_sql_text(
+                "task_info->'tmp_doc_metadata'->>'project_id' = :project_id",
+                project_id=project_id,
+            ),
+            get_sql_text(
+                "task_info->'tmp_doc_metadata'->>'conversation_id' = :conversation_id",
+                conversation_id=conversation_id,
             ),
         )
         .all()
@@ -64,7 +68,7 @@ def get_all_waiting_by_type(
     return (
         session.query(TaskQueue)
         .filter(
-            text(f"task_info->>'project_id' = '{project_id}'"),
+            get_sql_text("task_info->>'project_id' = :project_id", project_id=project_id),
             TaskQueue.task_type == task_type.value,
             TaskQueue.is_active == False,
         )
@@ -78,8 +82,10 @@ def get_waiting_by_attribute_id(project_id: str, attribute_id: str) -> TaskQueue
         session.query(TaskQueue)
         .filter(
             TaskQueue.task_type == enums.TaskType.ATTRIBUTE_CALCULATION.value,
-            text(f"task_info->>'attribute_id' = '{attribute_id}'"),
-            text(f"task_info->>'project_id' = '{project_id}'"),
+            get_sql_text(
+                "task_info->>'attribute_id' = :attribute_id", attribute_id=attribute_id
+            ),
+            get_sql_text("task_info->>'project_id' = :project_id", project_id=project_id),
             TaskQueue.is_active == False,
         )
         .first()
@@ -87,13 +93,12 @@ def get_waiting_by_attribute_id(project_id: str, attribute_id: str) -> TaskQueue
 
 
 def get_waiting_by_information_source(project_id: str, source_id: str) -> TaskQueue:
-    source_id = prevent_sql_injection(source_id, isinstance(source_id, str))
     return (
         session.query(TaskQueue)
         .filter(
             TaskQueue.task_type == enums.TaskType.INFORMATION_SOURCE.value,
-            text(f"task_info->>'information_source_id' = '{source_id}'"),
-            text(f"task_info->>'project_id' = '{project_id}'"),
+            get_sql_text("task_info->>'information_source_id' = :source_id", source_id=source_id),
+            get_sql_text("task_info->>'project_id' = :project_id", project_id=project_id),
             TaskQueue.is_active == False,
         )
         .first()
@@ -103,15 +108,15 @@ def get_waiting_by_information_source(project_id: str, source_id: str) -> TaskQu
 def get_waiting_by_macro_group_execution_ids(
     project_id: str, source_ids: List[str]
 ) -> TaskQueue:
-    source_ids = prevent_sql_injection(source_ids, isinstance(source_ids, list))
     return (
         session.query(TaskQueue)
         .filter(
             TaskQueue.task_type == enums.TaskType.RUN_COGNITION_MACRO.value,
-            text(
-                f"task_info->>'group_execution_id' IN ({','.join(map(repr, source_ids))})"
+            get_sql_text(
+                "task_info->>'group_execution_id' IN :source_ids",
+                source_ids=tuple(source_ids),
             ),
-            text(f"task_info->>'project_id' = '{project_id}'"),
+            get_sql_text("task_info->>'project_id' = :project_id", project_id=project_id),
         )
         .first()
     )
@@ -124,7 +129,7 @@ def get_by_tokenization(project_id: str) -> TaskQueue:
         session.query(TaskQueue)
         .filter(
             TaskQueue.task_type == enums.TaskType.TOKENIZATION.value,
-            text(f"task_info->>'project_id' = '{project_id}'"),
+            get_sql_text("task_info->>'project_id' = :project_id", project_id=project_id),
         )
         .order_by(TaskQueue.created_at.asc())
         .first()

--- a/sql_validator/injection_tests.py
+++ b/sql_validator/injection_tests.py
@@ -19,13 +19,33 @@ validate_sql_clause = _get_validate()
 
 def run_tests():
     # Dynamic import from tests/ folder
-    test_files = [f[:-3] for f in os.listdir("tests") if f.endswith(".py") and f != "__init__.py"]
-    
+    test_dir = os.path.join(os.path.dirname(__file__), "tests")
+    test_files = [
+        f[:-3]
+        for f in os.listdir(test_dir)
+        if f.endswith(".py") and f != "__init__.py"
+    ]
+
     all_valid = []
     all_invalid = []
-    
+
+    # Whitelist of allowed test modules to prevent arbitrary code execution
+    allowed_test_files = {
+        "complex_queries",
+        "complexity_cases",
+        "injection_cases",
+        "multi_clause_cases",
+        "order_group_cases",
+        "subquery_cases",
+        "tautology_cases",
+        "valid_cases",
+        "window_function_cases",
+    }
+
     for test_file in test_files:
-        module = importlib.import_module(f"tests.{test_file}")
+        if test_file not in allowed_test_files:
+            continue
+        module = importlib.import_module(f".tests.{test_file}", package=__package__)
         if hasattr(module, "VALID_CASES"):
             all_valid.extend(module.VALID_CASES)
         if hasattr(module, "INVALID_CASES"):

--- a/util.py
+++ b/util.py
@@ -326,3 +326,7 @@ def __mask_sql_str(sql_str: str, remove_quotes: bool) -> str:
 
 def ensure_sql_text(sql: str) -> str:
     return sql_text(sql)
+
+
+def get_sql_text(sql: str, **params) -> str:
+    return sql_text(sql).bindparams(**params)


### PR DESCRIPTION
Automated opengrep resolution: static-analysis findings fixed by Cursor Agent. Please review the changes and verify correctness.

### Included changes
- `business_objects/task_queue.py:44` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:45` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:67` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:81` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:82` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:95` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:96` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:111` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:114` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:127` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `sql_validator/injection_tests.py:28` — **python.lang.security.audit.non-literal-import.non-literal-import** (WARNING)


**Main PR:** https://github.com/code-kern-ai/cognition-gateway/pull/306