### PR TITLE
opengrep: apply agent fixes

### DIFF
--- a/business_objects/task_queue.py
+++ b/business_objects/task_queue.py
@@ -1,12 +1,10 @@
 from typing import List, Optional, Dict, Union
-from sqlalchemy import text
 
 from . import general
 from .. import enums
 from ..models import TaskQueue, Project
 from ..session import session
-
-from ..util import prevent_sql_injection
+from ..util import safe_text_with_bindparams, safe_text_in_clause
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql.expression import cast
 from datetime import datetime, timedelta
@@ -41,9 +39,13 @@ def get_all_queued_etl_task_for_conversation(
         .filter(
             TaskQueue.organization_id == org_id,
             TaskQueue.task_type == enums.TaskType.EXECUTE_ETL.value,
-            text(f"task_info->'tmp_doc_metadata'->>'project_id' = '{project_id}'"),
-            text(
-                f"task_info->'tmp_doc_metadata'->>'conversation_id' = '{conversation_id}'"
+            safe_text_with_bindparams(
+                "task_info->'tmp_doc_metadata'->>'project_id' = :project_id",
+                project_id=project_id,
+            ),
+            safe_text_with_bindparams(
+                "task_info->'tmp_doc_metadata'->>'conversation_id' = :conversation_id",
+                conversation_id=conversation_id,
             ),
         )
         .all()
@@ -64,7 +66,9 @@ def get_all_waiting_by_type(
     return (
         session.query(TaskQueue)
         .filter(
-            text(f"task_info->>'project_id' = '{project_id}'"),
+            safe_text_with_bindparams(
+                "task_info->>'project_id' = :project_id", project_id=project_id
+            ),
             TaskQueue.task_type == task_type.value,
             TaskQueue.is_active == False,
         )
@@ -78,8 +82,13 @@ def get_waiting_by_attribute_id(project_id: str, attribute_id: str) -> TaskQueue
         session.query(TaskQueue)
         .filter(
             TaskQueue.task_type == enums.TaskType.ATTRIBUTE_CALCULATION.value,
-            text(f"task_info->>'attribute_id' = '{attribute_id}'"),
-            text(f"task_info->>'project_id' = '{project_id}'"),
+            safe_text_with_bindparams(
+                "task_info->>'attribute_id' = :attribute_id",
+                attribute_id=attribute_id,
+            ),
+            safe_text_with_bindparams(
+                "task_info->>'project_id' = :project_id", project_id=project_id
+            ),
             TaskQueue.is_active == False,
         )
         .first()
@@ -87,13 +96,17 @@ def get_waiting_by_attribute_id(project_id: str, attribute_id: str) -> TaskQueue
 
 
 def get_waiting_by_information_source(project_id: str, source_id: str) -> TaskQueue:
-    source_id = prevent_sql_injection(source_id, isinstance(source_id, str))
     return (
         session.query(TaskQueue)
         .filter(
             TaskQueue.task_type == enums.TaskType.INFORMATION_SOURCE.value,
-            text(f"task_info->>'information_source_id' = '{source_id}'"),
-            text(f"task_info->>'project_id' = '{project_id}'"),
+            safe_text_with_bindparams(
+                "task_info->>'information_source_id' = :source_id",
+                source_id=source_id,
+            ),
+            safe_text_with_bindparams(
+                "task_info->>'project_id' = :project_id", project_id=project_id
+            ),
             TaskQueue.is_active == False,
         )
         .first()
@@ -103,15 +116,14 @@ def get_waiting_by_information_source(project_id: str, source_id: str) -> TaskQu
 def get_waiting_by_macro_group_execution_ids(
     project_id: str, source_ids: List[str]
 ) -> TaskQueue:
-    source_ids = prevent_sql_injection(source_ids, isinstance(source_ids, list))
     return (
         session.query(TaskQueue)
         .filter(
             TaskQueue.task_type == enums.TaskType.RUN_COGNITION_MACRO.value,
-            text(
-                f"task_info->>'group_execution_id' IN ({','.join(map(repr, source_ids))})"
+            safe_text_in_clause("task_info->>'group_execution_id'", source_ids),
+            safe_text_with_bindparams(
+                "task_info->>'project_id' = :project_id", project_id=project_id
             ),
-            text(f"task_info->>'project_id' = '{project_id}'"),
         )
         .first()
     )
@@ -124,7 +136,9 @@ def get_by_tokenization(project_id: str) -> TaskQueue:
         session.query(TaskQueue)
         .filter(
             TaskQueue.task_type == enums.TaskType.TOKENIZATION.value,
-            text(f"task_info->>'project_id' = '{project_id}'"),
+            safe_text_with_bindparams(
+                "task_info->>'project_id' = :project_id", project_id=project_id
+            ),
         )
         .order_by(TaskQueue.created_at.asc())
         .first()

--- a/sql_validator/injection_tests.py
+++ b/sql_validator/injection_tests.py
@@ -1,7 +1,12 @@
 # injection_tests.py
 import os
+import re
 import sys
 import importlib
+
+# Only allow alphanumeric and underscore in test module names (no path traversal or injection).
+_SAFE_TEST_MODULE_PATTERN = re.compile(r"^[a-zA-Z0-9_]+$")
+
 
 def _get_validate():
     try:
@@ -18,14 +23,16 @@ def _get_validate():
 validate_sql_clause = _get_validate()
 
 def run_tests():
-    # Dynamic import from tests/ folder
+    # Dynamic import from tests/ folder; only allow whitelisted module names.
     test_files = [f[:-3] for f in os.listdir("tests") if f.endswith(".py") and f != "__init__.py"]
-    
+
     all_valid = []
     all_invalid = []
-    
+
     for test_file in test_files:
-        module = importlib.import_module(f"tests.{test_file}")
+        if not _SAFE_TEST_MODULE_PATTERN.match(test_file):
+            continue
+        module = importlib.import_module("tests." + test_file)
         if hasattr(module, "VALID_CASES"):
             all_valid.extend(module.VALID_CASES)
         if hasattr(module, "INVALID_CASES"):

--- a/util.py
+++ b/util.py
@@ -326,3 +326,33 @@ def __mask_sql_str(sql_str: str, remove_quotes: bool) -> str:
 
 def ensure_sql_text(sql: str) -> str:
     return sql_text(sql)
+
+
+def safe_text_with_bindparams(sql_template: str, **bind_params: Any):
+    """
+    Build a SQLAlchemy text() clause with bound parameters to avoid SQL injection.
+    Use this instead of text(f\"...\") when variable values must be included in the query.
+    sql_template must be a constant string with named placeholders (:name).
+    All variable values must be passed as keyword arguments; they are sent as bound parameters.
+    Returns a SQLAlchemy text() construct suitable for use in filter(), etc.
+    """
+    from sqlalchemy import text
+
+    return text(sql_template).bindparams(**bind_params)
+
+
+def safe_text_in_clause(column_expression: str, values: List[str]):
+    """
+    Build a SQLAlchemy text() clause for column_expression IN (values) with bound parameters.
+    Use instead of text(f\"... IN ({','.join(...)})\") to avoid SQL injection.
+    column_expression must be a constant (e.g. \"task_info->>'group_execution_id'\").
+    values are passed as bound parameters.
+    """
+    from sqlalchemy import text
+
+    if not values:
+        raise ValueError("safe_text_in_clause requires at least one value")
+    placeholders = ", ".join(":p" + str(i) for i in range(len(values)))
+    sql = column_expression + " IN (" + placeholders + ")"
+    params = {"p" + str(i): v for i, v in enumerate(values)}
+    return text(sql).bindparams(**params)


### PR DESCRIPTION
Automated opengrep resolution: static-analysis findings fixed by Cursor Agent. Please review the changes and verify correctness.

### Included changes
- `business_objects/task_queue.py:45` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:67` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:81` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:82` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:95` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:96` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:111` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:114` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `business_objects/task_queue.py:127` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)
- `sql_validator/injection_tests.py:28` — **python.lang.security.audit.non-literal-import.non-literal-import** (WARNING)

**Main PR:** https://github.com/code-kern-ai/refinery-gateway/pull/386