### PR TITLE
opengrep: apply agent fixes

### DIFF
--- a/sql_validator/injection_tests.py
+++ b/sql_validator/injection_tests.py
@@ -7,6 +7,39 @@ import importlib
 # Only allow alphanumeric and underscore in test module names (no path traversal or injection).
 _SAFE_TEST_MODULE_PATTERN = re.compile(r"^[a-zA-Z0-9_]+$")
 
+# Literal whitelist of test module names (no dynamic construction for import_module).
+_ALLOWED_TEST_MODULES = frozenset({
+    "complex_queries", "complexity_cases", "injection_cases", "multi_clause_cases",
+    "order_group_cases", "subquery_cases", "tautology_cases", "valid_cases",
+    "window_function_cases",
+})
+
+
+def _import_test_module(name: str):
+    """Import a test module by name; only allowed names are imported (literal paths only)."""
+    if name not in _ALLOWED_TEST_MODULES:
+        raise ValueError(f"Test module not in whitelist: {name}")
+    # Dispatch with literal-only arguments so import_module never receives a dynamic string.
+    if name == "complex_queries":
+        return importlib.import_module("tests.complex_queries")
+    if name == "complexity_cases":
+        return importlib.import_module("tests.complexity_cases")
+    if name == "injection_cases":
+        return importlib.import_module("tests.injection_cases")
+    if name == "multi_clause_cases":
+        return importlib.import_module("tests.multi_clause_cases")
+    if name == "order_group_cases":
+        return importlib.import_module("tests.order_group_cases")
+    if name == "subquery_cases":
+        return importlib.import_module("tests.subquery_cases")
+    if name == "tautology_cases":
+        return importlib.import_module("tests.tautology_cases")
+    if name == "valid_cases":
+        return importlib.import_module("tests.valid_cases")
+    if name == "window_function_cases":
+        return importlib.import_module("tests.window_function_cases")
+    raise ValueError(f"Test module not in whitelist: {name}")
+
 
 def _get_validate():
     try:
@@ -30,9 +63,9 @@ def run_tests():
     all_invalid = []
 
     for test_file in test_files:
-        if not _SAFE_TEST_MODULE_PATTERN.match(test_file):
+        if not _SAFE_TEST_MODULE_PATTERN.match(test_file) or test_file not in _ALLOWED_TEST_MODULES:
             continue
-        module = importlib.import_module("tests." + test_file)
+        module = _import_test_module(test_file)
         if hasattr(module, "VALID_CASES"):
             all_valid.extend(module.VALID_CASES)
         if hasattr(module, "INVALID_CASES"):

--- a/util.py
+++ b/util.py
@@ -343,16 +343,13 @@ def safe_text_with_bindparams(sql_template: str, **bind_params: Any):
 
 def safe_text_in_clause(column_expression: str, values: List[str]):
     """
-    Build a SQLAlchemy text() clause for column_expression IN (values) with bound parameters.
-    Use instead of text(f\"... IN ({','.join(...)})\") to avoid SQL injection.
+    Build a SQLAlchemy clause for column_expression IN (values) with bound parameters.
+    Uses literal_column + in_() instead of text() so the usual SQL injection protections apply.
     column_expression must be a constant (e.g. \"task_info->>'group_execution_id'\").
     values are passed as bound parameters.
     """
-    from sqlalchemy import text
+    from sqlalchemy.sql.expression import literal_column
 
     if not values:
         raise ValueError("safe_text_in_clause requires at least one value")
-    placeholders = ", ".join(":p" + str(i) for i in range(len(values)))
-    sql = column_expression + " IN (" + placeholders + ")"
-    params = {"p" + str(i): v for i, v in enumerate(values)}
-    return text(sql).bindparams(**params)
+    return literal_column(column_expression).in_(values)


### PR DESCRIPTION
Automated opengrep resolution: static-analysis findings fixed by Cursor Agent. Please review the changes and verify correctness.

## Related PRs
- [main] **refinery-submodule-model**: https://github.com/code-kern-ai/refinery-submodule-model/pull/227

## Included changes
- `sql_validator/injection_tests.py:35` — **python.lang.security.audit.non-literal-import.non-literal-import** (WARNING)
- `util.py:358` — **python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text** (ERROR)